### PR TITLE
docs: document how to reduce repeated approval prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,18 @@ Windows 用户可使用官方 PowerShell 安装命令：`powershell -ExecutionPo
 
 如果 `codex --version` 能正常输出版本号，就可以继续安装本项目的 Codex skills。
 
+#### 减少授权确认
+
+这些 skills 会频繁调用工具，Claude Code 默认会逐次请求授权确认。这个行为来自 Claude Code 客户端权限机制，不是本仓库可以修改的默认设置。
+
+如果你信任当前 workflow，并且在可信环境中运行，可以用 Claude Code 的跳过权限确认模式启动：
+
+```bash
+claude --dangerously-skip-permissions
+```
+
+注意：该模式会关闭 Claude Code 的工具审批保护，只应在你信任仓库、命令和工作目录的情况下使用。
+
 ### 2. 安装 Skills
 
 Claude Code 用户安装：

--- a/README_EN.md
+++ b/README_EN.md
@@ -248,6 +248,18 @@ Windows users can use the official PowerShell installer: `powershell -ExecutionP
 
 If `codex --version` prints a version, you can continue with this project's Codex skills installation.
 
+#### Reducing Approval Prompts
+
+These skills issue many tool calls, and Claude Code asks for approval for each one by default. That behavior comes from Claude Code's client-side permission system; it is not a repository default this project can change.
+
+If you trust the current workflow and are running in a trusted environment, start Claude Code in skip-permissions mode:
+
+```bash
+claude --dangerously-skip-permissions
+```
+
+Warning: this disables Claude Code's tool-approval guardrails. Use it only when you trust the repository, commands, and working directory.
+
 ### 2. Install Skills
 
 For Claude Code users:


### PR DESCRIPTION
## Summary
Add a brief "减少授权确认 / Reducing approval prompts" note to the Quick Start section of both README.md and README_EN.md. Document that the skills issue many tool calls and that users who trust the workflow can run Claude Code in bypass / skip-permissions mode (`claude --dangerously-skip-permissions`) to avoid repeated confirmation, exactly as the maintainer recommended in the thread. Include a short safety caveat that this disables Claude Code's tool-approval guardrails so it should only be used in a trusted environment.

## Why this matters
A user reports having to click "approve" hundreds of times while running the skills and asks whether tool execution can default to yes. The friction comes from Claude Code's per-tool permission prompts, which the repo itself does not control. The maintainer (xbtlin) replied on 2026-06-23 endorsing a concrete workaround: switch Claude Code into bypass mode, and a community member added the exact flag `claude --dangerously-skip-permissions`. The workaround is established and maintainer-endorsed but is not captured anywhere in the README, so each new user hits the same wall.

See https://github.com/xbtlin/ai-berkshire/issues/9.

## Testing
- Happy path: both READMEs render the new note under Quick Start with the correct flag spelled exactly `--dangerously-skip-permissions`. - Edge case: the safety caveat is present in both language versions so the guidance is not framed as unconditionally safe. - Error path: no claim is made that the repo can change Claude Code's default permission behavior (the note only points at the client-side flag the maintainer endorsed).

Fixes #9

AI was used for assistance.
