### PR TITLE
Add Windows installers for Claude and Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,10 @@ validation tools. Keep compatibility with both Claude Code and Codex users.
 - `reports/`: research outputs. Do not rewrite unrelated reports while changing
   tooling or skills.
 - `scripts/sync-codex-skills.py`: regenerates Codex skills from `skills/*.md`.
-- `scripts/install-codex-skills.sh`: installs Codex skills locally.
-- `scripts/install-codex-prompts.sh`: installs generated Codex slash prompts
-  locally.
+- `scripts/install-codex-skills.sh` / `scripts/install-codex-skills.bat`:
+  installs Codex skills locally.
+- `scripts/install-codex-prompts.sh` / `scripts/install-codex-prompts.bat`:
+  installs generated Codex slash prompts locally.
 - `scripts/install-claude-commands.sh`: installs Claude Code commands locally.
 
 ## Compatibility Rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ validation tools. Keep compatibility with both Claude Code and Codex users.
   installs Codex skills locally.
 - `scripts/install-codex-prompts.sh` / `scripts/install-codex-prompts.bat`:
   installs generated Codex slash prompts locally.
-- `scripts/install-claude-commands.sh`: installs Claude Code commands locally.
+- `scripts/install-claude-commands.sh` / `scripts/install-claude-commands.bat`:
+  installs Claude Code commands locally.
 
 ## Compatibility Rules
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ cd ai-berkshire
 ./scripts/install-claude-commands.sh
 ```
 
-Codex 用户安装：
+Codex 用户安装（macOS / Linux）：
 
 ```bash
 # 克隆仓库
@@ -289,6 +289,17 @@ cd ai-berkshire
 # 可选：安装 Codex slash prompts 到 ~/.codex/prompts
 # 用于获得接近 Claude Code 的 /investment-research 体验
 ./scripts/install-codex-prompts.sh
+```
+
+Codex 用户安装（Windows PowerShell / Command Prompt）：
+
+```bat
+git clone https://github.com/xbtlin/ai-berkshire.git
+cd ai-berkshire
+.\scripts\install-codex-skills.bat
+
+REM 可选：安装 Codex slash prompts
+.\scripts\install-codex-prompts.bat
 ```
 
 仓库同时维护三套入口：`skills/*.md` 是 Claude Code command 源文件；`codex-skills/*/SKILL.md` 是 Codex skill 包，由 `scripts/sync-codex-skills.py` 从 `skills/*.md` 生成；`codex-prompts/*.md` 是可选的 Codex slash prompt 兼容层。

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ claude --dangerously-skip-permissions
 
 ### 2. 安装 Skills
 
-Claude Code 用户安装：
+Claude Code 用户安装（macOS / Linux）：
 
 ```bash
 # 克隆仓库
@@ -274,6 +274,14 @@ git clone https://github.com/xbtlin/ai-berkshire.git
 # 复制 skills 到 Claude Code 全局 commands 目录
 cd ai-berkshire
 ./scripts/install-claude-commands.sh
+```
+
+Claude Code 用户安装（Windows PowerShell / Command Prompt）：
+
+```bat
+git clone https://github.com/xbtlin/ai-berkshire.git
+cd ai-berkshire
+.\scripts\install-claude-commands.bat
 ```
 
 Codex 用户安装（macOS / Linux）：

--- a/README_EN.md
+++ b/README_EN.md
@@ -232,7 +232,7 @@ For Claude Code users:
 npm install -g @anthropic-ai/claude-code
 ```
 
-For Codex users:
+For Codex users on macOS / Linux:
 
 ```bash
 # macOS / Linux
@@ -290,6 +290,17 @@ cd ai-berkshire
 # Optional: install Codex slash prompts to ~/.codex/prompts
 # for a Claude Code-like /investment-research entry point
 ./scripts/install-codex-prompts.sh
+```
+
+For Codex users on Windows PowerShell / Command Prompt:
+
+```bat
+git clone https://github.com/xbtlin/ai-berkshire.git
+cd ai-berkshire
+.\scripts\install-codex-skills.bat
+
+REM Optional: install Codex slash prompts
+.\scripts\install-codex-prompts.bat
 ```
 
 The repository maintains three entry points: `skills/*.md` are the Claude Code command sources; `codex-skills/*/SKILL.md` are Codex skill packages generated from `skills/*.md` by `scripts/sync-codex-skills.py`; `codex-prompts/*.md` are an optional Codex slash-prompt compatibility layer.

--- a/README_EN.md
+++ b/README_EN.md
@@ -266,7 +266,7 @@ Warning: this disables Claude Code's tool-approval guardrails. Use it only when 
 
 ### 2. Install Skills
 
-For Claude Code users:
+For Claude Code users on macOS / Linux:
 
 ```bash
 # Clone the repository
@@ -277,7 +277,15 @@ cd ai-berkshire
 ./scripts/install-claude-commands.sh
 ```
 
-For Codex users:
+For Claude Code users on Windows PowerShell / Command Prompt:
+
+```bat
+git clone https://github.com/xbtlin/ai-berkshire.git
+cd ai-berkshire
+.\scripts\install-claude-commands.bat
+```
+
+For Codex users on macOS / Linux:
 
 ```bash
 # Clone the repository

--- a/scripts/install-claude-commands.bat
+++ b/scripts/install-claude-commands.bat
@@ -1,0 +1,18 @@
+@echo off
+setlocal
+
+for %%I in ("%~dp0..") do set "ROOT=%%~fI"
+
+if defined CLAUDE_COMMANDS_DIR (
+  set "DEST=%CLAUDE_COMMANDS_DIR%"
+) else (
+  set "DEST=%USERPROFILE%\.claude\commands"
+)
+
+if not exist "%DEST%" mkdir "%DEST%"
+if errorlevel 1 exit /b %ERRORLEVEL%
+
+copy /Y "%ROOT%\skills\*.md" "%DEST%\" >nul
+if errorlevel 1 exit /b %ERRORLEVEL%
+
+echo Installed Claude Code commands to %DEST%

--- a/scripts/install-codex-prompts.bat
+++ b/scripts/install-codex-prompts.bat
@@ -1,0 +1,29 @@
+@echo off
+setlocal
+
+for %%I in ("%~dp0..") do set "ROOT=%%~fI"
+
+if defined CODEX_HOME (
+  set "DEST=%CODEX_HOME%\prompts"
+) else (
+  set "DEST=%USERPROFILE%\.codex\prompts"
+)
+
+where py >nul 2>nul
+if %ERRORLEVEL%==0 (
+  set "PY=py -3"
+) else (
+  set "PY=python"
+)
+
+%PY% "%ROOT%\scripts\sync-codex-prompts.py"
+if errorlevel 1 exit /b %ERRORLEVEL%
+
+if not exist "%DEST%" mkdir "%DEST%"
+if errorlevel 1 exit /b %ERRORLEVEL%
+
+copy /Y "%ROOT%\codex-prompts\*.md" "%DEST%\" >nul
+if errorlevel 1 exit /b %ERRORLEVEL%
+
+echo Installed Codex slash prompts to %DEST%
+echo Restart Codex to pick up new slash prompts.

--- a/scripts/install-codex-skills.bat
+++ b/scripts/install-codex-skills.bat
@@ -1,0 +1,34 @@
+@echo off
+setlocal
+
+for %%I in ("%~dp0..") do set "ROOT=%%~fI"
+
+if defined CODEX_HOME (
+  set "DEST=%CODEX_HOME%\skills"
+) else (
+  set "DEST=%USERPROFILE%\.codex\skills"
+)
+
+where py >nul 2>nul
+if %ERRORLEVEL%==0 (
+  set "PY=py -3"
+) else (
+  set "PY=python"
+)
+
+%PY% "%ROOT%\scripts\sync-codex-skills.py"
+if errorlevel 1 exit /b %ERRORLEVEL%
+
+if not exist "%DEST%" mkdir "%DEST%"
+if errorlevel 1 exit /b %ERRORLEVEL%
+
+for /d %%D in ("%ROOT%\codex-skills\*") do (
+  if exist "%DEST%\%%~nxD" rmdir /s /q "%DEST%\%%~nxD"
+  if errorlevel 1 exit /b 1
+  xcopy "%%~fD" "%DEST%\%%~nxD\" /E /I /Y >nul
+  if errorlevel 1 exit /b 1
+)
+
+echo Installed Codex skills to %DEST%
+echo Run .\scripts\install-codex-prompts.bat if you want slash-command prompts.
+echo Restart Codex to pick up new skills.


### PR DESCRIPTION
## What changed
- Added Windows `.bat` installers for Claude Code commands, Codex skills, and optional Codex slash prompts.
- Updated AGENTS.md, README.md, and README_EN.md so Windows users get native install commands while macOS/Linux users keep the existing `.sh` path.

## Why
The existing local install scripts were Bash-only, which made the documented install path awkward on Windows. This adds native Windows paths without removing the Unix scripts.

## Verification
- `cmd /c "set CLAUDE_COMMANDS_DIR=%TEMP%\ai-berkshire-claude-test&& scripts\install-claude-commands.bat"`
- Confirmed the temp Claude commands directory contains 18 `.md` command files.
- `cmd /c "set CODEX_HOME=%TEMP%\ai-berkshire-codex-test&& scripts\install-codex-skills.bat"`
- `cmd /c "set CODEX_HOME=%TEMP%\ai-berkshire-codex-test&& scripts\install-codex-prompts.bat"`
- `python scripts/sync-codex-skills.py --check`
- `python scripts/sync-codex-prompts.py --check`
- `git diff --check`