### PR TITLE
修复 codex-prompts 漂移，并新增 CI 拦截复发

### DIFF
--- a/codex-prompts/deep-company-series.md
+++ b/codex-prompts/deep-company-series.md
@@ -1,5 +1,5 @@
 ---
-description: "AI Berkshire slash entry for 深度公司系列：8 篇长文拆一家公司."
+description: "AI Berkshire slash entry for 看懂XX公司（深度公司系列）：3-8 篇长文拆一家公司."
 argument-hint: $ARGUMENTS
 ---
 


### PR DESCRIPTION
## 背景

`skills/deep-company-series.md` 的一级标题此前被改动：

```diff
- # 深度公司系列：8 篇长文拆一家公司
+ # 看懂XX公司（深度公司系列）：3-8 篇长文拆一家公司
```

但当时只跑了 `sync-codex-skills.py`，**漏跑了 `sync-codex-prompts.py`**，导致 Codex slash 入口的 `description` 停留在旧标题。

按 `AGENTS.md` 的兼容性规范，改动 `skills/` 后需同时同步两个生成层。本 PR 先修数据，再补上防止复发的自动化拦截。

---

## 改动 1：修复漂移

跑 `python scripts/sync-codex-prompts.py` 重新生成。20 个 prompts 中**仅此 1 个**存在漂移，改动为单行：

```diff
- description: "AI Berkshire slash entry for 深度公司系列：8 篇长文拆一家公司."
+ description: "AI Berkshire slash entry for 看懂XX公司（深度公司系列）：3-8 篇长文拆一家公司."
```

无手工编辑，纯脚本产出。

## 改动 2：新增 CI 拦截复发

本次漂移能溜进主干，根因是**没有任何自动化检查**。新增 `.github/workflows/ci.yml`（仓库此前无 workflow），在 PR 与 push 到 main 时执行四步：

| # | 步骤 | 作用 |
|---|---|---|
| 1 | `sync-codex-skills.py --check` | `codex-skills/` 是否与 `skills/` 同步 |
| 2 | `sync-codex-prompts.py --check` | `codex-prompts/` 是否与 `skills/` 同步 |
| 3 | `tests/test_financial_rigor.py` | 估值计算工具回归 |
| 4 | `tests/test_report_audit.py` | 报告抽检工具回归 |

设计取舍：

- 前两步复用 `AGENTS.md` 已规定的 `--check` 模式 —— **只校验、不写文件**，CI 不会产生意外提交
- 后两步是仓库**现有**的 unittest 套件，此前从未被自动调用
- 无第三方依赖，`actions/setup-python` 即可运行；加了 `concurrency` 取消过期运行，`permissions: contents: read` 收敛权限

## 验证

**干净状态**（模拟 CI 四步）：

```
PASS  sync-codex-skills --check
PASS  sync-codex-prompts --check
PASS  test_financial_rigor
PASS  test_report_audit
==> CI would PASS
```

**注入漂移**（改 `skills/` 标题但不跑同步，验证真能拦下来，随后已还原）：

```
sync-codex-skills  exit=1
sync-codex-prompts exit=1   Codex prompts are out of date: codex-prompts\deep-company-series.md
```

workflow YAML 经 PyYAML 解析通过。

## 影响面

- `codex-prompts/*.md` 是**可选的 slash 命令兼容层**，内容仅为转发存根（指向 `codex-skills/*/SKILL.md`），修复的是 `/deep-company-series` 的描述文案
- ✅ 不影响任何研究工作流逻辑
- ✅ 不涉及 `skills/`、`tools/`、`reports/`
