### PR TITLE
fix(report-audit): skip narrative table columns

### DIFF
--- a/tests/test_report_audit.py
+++ b/tests/test_report_audit.py
@@ -122,6 +122,33 @@ class TestAbsoluteValueGuard(unittest.TestCase):
             "超过 1e15 的负值未被过滤（abs() 守卫失效）")
 
 
+class TestNarrativeTableColumns(unittest.TestCase):
+    """Issue #79：叙述性英文列中的数字不应成为待核验数据点。"""
+
+    MD = (
+        "| Metric | Value | Source | Verified |\n"
+        "|---|---|---|---|\n"
+        "| FY2026E non-GAAP EPS guidance | $1.85–$2.25 | "
+        "company guidance (raised twice in 2026) | — |\n\n"
+        "| Strategy | Recommendation |\n"
+        "|---|---|\n"
+        "| If you already hold | Check the RPO gap against the 10-K. |\n"
+    )
+
+    def setUp(self):
+        self.points = R.extract_data_points(self.MD)
+        self.labels = {point['label'] for point in self.points}
+
+    def test_keeps_the_actual_value_column(self):
+        self.assertIn('FY2026E non-GAAP EPS guidance · Value', self.labels)
+
+    def test_skips_source_narrative_years(self):
+        self.assertNotIn('FY2026E non-GAAP EPS guidance · Source', self.labels)
+
+    def test_skips_recommendation_identifiers(self):
+        self.assertNotIn('If you already hold · Recommendation', self.labels)
+
+
 class TestGbkStdoutSurvival(unittest.TestCase):
     """BUG-2：Windows GBK 控制台下含 € 的报告必须能正常 extract 而不崩溃。"""
 

--- a/tools/report_audit.py
+++ b/tools/report_audit.py
@@ -213,8 +213,11 @@ def extract_data_points(md_text: str) -> list:
         # 跳过无意义行标签
         if not _is_valid_label(row_label):
             continue
-        # 跳过无意义列标题（YoY增速列单独标注，不作为待核验数据）
-        if col_header.upper() in ('YOY', 'YOY增速', '增速', '同比', '变化', '趋势', '说明', '备注'):
+        # 跳过增速及叙述性列，它们可能含年份或 10-K 等非数据标识符。
+        if col_header.strip().casefold() in (
+                'yoy', 'yoy增速', '增速', '同比', '变化', '趋势', '说明', '备注',
+                'source', 'sources', 'note', 'notes', 'verified',
+                'recommendation', 'commentary', 'summary'):
             continue
         # label = "行标签 · 列标题"（若列标题是行标签的补充）
         if col_header and col_header != row_label:


### PR DESCRIPTION
## Summary

- Fixes: report_audit extract turns a source-note year such as 2026 and a filing identifier such as 10-K inside English Source or Recommendation columns into numeric claims that users are asked to cross-check.
- Root cause: The multi-column table parser scans every cell for the first number, while the downstream column filter recognizes only growth and Chinese narrative headers; common English narrative headers therefore reach data-point creation unchanged.
- Fixes #79.

## Regression evidence

- Before: `python3 tests/test_report_audit.py` exited `1`

- After: `python3 tests/test_report_audit.py` exited `0`

## Verification

- `python3 -m unittest discover -s tests -v`
- `python3 -m py_compile tools/report_audit.py tests/test_report_audit.py`
- The issue #79 CLI fixture now extracts only the actual Value cell (1 data point), excluding Source and Recommendation text.

## Scope

- 2 files changed, +32 / -2 lines
