### PR TITLE
fix(skills): give earnings-review a distinct output filename (issue #98)

### DIFF
--- a/codex-prompts/deep-company-series.md
+++ b/codex-prompts/deep-company-series.md
@@ -1,5 +1,5 @@
 ---
-description: "AI Berkshire slash entry for 深度公司系列：8 篇长文拆一家公司."
+description: "AI Berkshire slash entry for 看懂XX公司（深度公司系列）：3-8 篇长文拆一家公司."
 argument-hint: $ARGUMENTS
 ---
 

--- a/codex-skills/earnings-review/SKILL.md
+++ b/codex-skills/earnings-review/SKILL.md
@@ -203,7 +203,10 @@ python3 tools/financial_rigor.py verify-valuation \
 
 ### 第七步：保存报告
 
-将报告写入 `reports/{公司名}-earnings-{期间}.md`，例如 `reports/腾讯-earnings-2025Q4.md`
+将报告写入 `reports/{公司名}-earnings-{期间}-精读.md`，例如 `reports/腾讯-earnings-2025Q4-精读.md`
+
+> 命名约定：`-精读` 后缀用于区分本 skill 的一手资料精读报告；`earnings-team` 的最终公众号文章使用
+> 不带后缀的 `{公司名}-earnings-{期间}.md`，两个 skill 先后运行不会互相覆盖。
 
 ### 第八步：数据抽检（准出流程）
 
@@ -212,7 +215,7 @@ python3 tools/financial_rigor.py verify-valuation \
 ```bash
 # Step 1 — 提取抽检清单
 python3 tools/report_audit.py extract \
-  --report reports/{公司名}-earnings-{期间}.md
+  --report reports/{公司名}-earnings-{期间}-精读.md
 
 # Step 2 — 对清单每项从可靠信源取数（参见 skills/financial-data.md）
 

--- a/skills/earnings-review.md
+++ b/skills/earnings-review.md
@@ -188,7 +188,10 @@ python3 tools/financial_rigor.py verify-valuation \
 
 ### 第七步：保存报告
 
-将报告写入 `reports/{公司名}-earnings-{期间}.md`，例如 `reports/腾讯-earnings-2025Q4.md`
+将报告写入 `reports/{公司名}-earnings-{期间}-精读.md`，例如 `reports/腾讯-earnings-2025Q4-精读.md`
+
+> 命名约定：`-精读` 后缀用于区分本 skill 的一手资料精读报告；`earnings-team` 的最终公众号文章使用
+> 不带后缀的 `{公司名}-earnings-{期间}.md`，两个 skill 先后运行不会互相覆盖。
 
 ### 第八步：数据抽检（准出流程）
 
@@ -197,7 +200,7 @@ python3 tools/financial_rigor.py verify-valuation \
 ```bash
 # Step 1 — 提取抽检清单
 python3 tools/report_audit.py extract \
-  --report reports/{公司名}-earnings-{期间}.md
+  --report reports/{公司名}-earnings-{期间}-精读.md
 
 # Step 2 — 对清单每项从可靠信源取数（参见 skills/financial-data.md）
 


### PR DESCRIPTION
## Summary

Fixes #98: `earnings-team` and `earnings-review` both wrote
`reports/{公司名}-earnings-{期间}.md`, so running both skills in
sequence let the second overwrite the first.

Changes:
- `earnings-review` now saves to
  `reports/{公司名}-earnings-{期间}-精读.md` (e.g.
  `reports/腾讯-earnings-2025Q4-精读.md`), keeping the plain name for
  `earnings-team`'s final article. A naming-convention note was added
  to `skills/earnings-review.md`.
- The report-audit path in the same skill was updated to the new file.
- Regenerated `codex-skills/earnings-review/SKILL.md` from the
  canonical source per AGENTS.md.

Bonus: running `sync-codex-prompts.py` as part of the regeneration
also fixed the `codex-prompts/deep-company-series.md` description
drift (the same one-line fix proposed in PR #92, now produced by the
canonical sync tool). After this change `sync-codex-skills.py --check`
and `sync-codex-prompts.py --check` both pass.

## Verification

- `python3 scripts/sync-codex-skills.py --check` → PASS
- `python3 scripts/sync-codex-prompts.py --check` → PASS
- `python3 -m unittest discover -s tests -v` → 26 tests OK

## Scope

- 3 files changed, +11 / -5